### PR TITLE
ImageMode but fixed.

### DIFF
--- a/Sources/SwiftProcessing/Core/Images/SketchImage.swift
+++ b/Sources/SwiftProcessing/Core/Images/SketchImage.swift
@@ -138,8 +138,6 @@ public extension Sketch {
     
     /// Places an image in a sketch with an x and y position. Image placement is partially controlled by the `imageMode()` function. By default the x and y values are the upper-left- and upper-right-hand corner of the image.
     /// ```
-    /// // Tints the image to a UIColor, which is useful for color literals.
-    /// tint(ColorLiteral) // Typing ColorLiteral will bring up a color picker.
     /// image(image, 0, 0)
     /// ```
     /// - Parameters:
@@ -165,12 +163,12 @@ public extension Sketch {
     ///     - height: height of the image
 
     func image<X: Numeric, Y: Numeric, W: Numeric, H: Numeric>(_ image: Image, _ x: X, _ y: Y, _ width: W? = nil, _ height: H? = nil) {
-        let cg_x, cg_y: CGFloat
+        var cg_x, cg_y: CGFloat
         cg_x = x.convert()
         cg_y = y.convert()
         
-        let cg_w:CGFloat = width == nil ? CGFloat(image.width) : width!.convert()
-        let cg_h:CGFloat = height == nil ? CGFloat(image.height) : height!.convert()
+        var cg_w:CGFloat = width == nil ? CGFloat(image.width) : width!.convert()
+        var cg_h:CGFloat = height == nil ? CGFloat(image.height) : height!.convert()
                 
         image.width = Double(cg_w)
         image.height = Double(cg_h)
@@ -178,7 +176,7 @@ public extension Sketch {
         // We're going to manipulate the coordinate matrix, so we need to freeze everything.
         context?.saveGState()
         
-        imageModeHelper(cg_x, cg_y, cg_w, cg_h)
+        imageModeHelper(&cg_x, &cg_y, &cg_w, &cg_h)
         
         // Corners adjustment
         var newW = cg_w
@@ -194,12 +192,10 @@ public extension Sketch {
         context?.restoreGState()
     }
     
-    private func imageModeHelper(_ x: CGFloat, _ y: CGFloat, _ w: CGFloat, _ h: CGFloat) {
-        switch settings.ellipseMode {
+    private func imageModeHelper(_ x: inout CGFloat, _ y: inout CGFloat, _ width: inout CGFloat, _ height: inout CGFloat) {
+        switch settings.imageMode {
         case .center:
-            translate(-w * 0.5, -h * 0.5)
-        case .radius:
-            scale(0.5, 0.5)
+            translate(-width * 0.5, -height * 0.5)
         case .corner:
             return
         case .corners:

--- a/Sources/SwiftProcessing/Core/Sketch.swift
+++ b/Sources/SwiftProcessing/Core/Sketch.swift
@@ -108,7 +108,7 @@ import GameplayKit
         public static let strokeCap = StrokeCap.round
         public static let rectMode = ShapeMode.corner
         public static let ellipseMode = ShapeMode.center
-        public static let imageMode = ShapeMode.corner
+        public static let imageMode = ImageMode.corner
         public static let textFont = "HelveticaNeue"
         public static let textSize = 32.0
         public static let textLeading = 38.4 // Generally 120% of size. This is derived from Adobe's default treatment of leading.

--- a/Sources/SwiftProcessing/Core/SketchAttributes.swift
+++ b/Sources/SwiftProcessing/Core/SketchAttributes.swift
@@ -27,10 +27,11 @@ public protocol Attributes: Sketch {
     /// Draws all geometry with jagged (aliased) edges
     func noSmooth()
     
-    /// Modifies the location from which ellipses, circles, and arcs are drawn. The default mode is `.center`.
-    /// The default mode is `imageMode(.corner)`, which interprets the second and third parameters of `image()` as the upper-left corner of the image. If two additional parameters are specified, they are used to set the image's width and height.
-    /// `imageMode(.corners)` interprets the second and third parameters of `image()` as the location of one corner, and the fourth and fifth parameters as the opposite corner.
-    /// `imageMode(.center)` interprets the second and third parameters of `image()` as the image's center point. If two additional parameters are specified, they are used to set the image's width and height.
+    /// Modifies the location from which ellipses are drawn by changing the way in which parameters given to `ellipse()` are interpreted.
+    /// The default mode is `ellipseMode(.center)`, which interprets the first two parameters of `ellipse()` as the shape's center point, while the third and fourth parameters are its width and height.
+    /// `ellipseMode(.radius)` also uses the first two parameters of `ellipse()` as the shape's center point, but uses the third and fourth parameters to specify half of the shape's width and height.
+    /// `ellipseMode(.corner)` interprets the first two parameters of `ellipse()` as the upper-left corner of the shape, while the third and fourth parameters are its width and height.
+    /// `ellipseMode(.corners)` interprets the first two parameters of `ellipse()` as the location of one corner of the ellipse's bounding box, and the third and fourth parameters as the location of the opposite corner.
     /// - Parameter eMode: either `.center`, `.radius`, `.corner`, or `.corners`
     func ellipseMode(_ eMode: ShapeMode)
     
@@ -47,7 +48,7 @@ public protocol Attributes: Sketch {
     /// `imageMode(.corners)` interprets the second and third parameters of image() as the location of one corner, and the fourth and fifth parameters as the opposite corner.
     /// `imageMode(.center)` interprets the second and third parameters of image() as the image's center point. If two additional parameters are specified, they are used to set the image's width and height.
     /// - Parameter eMode: either `.center`, `.radius`, `.corner`, or `.corners`
-    func imageMode(_ iMode: ShapeMode)
+    func imageMode(_ iMode: ImageMode)
 }
 
 extension Sketch: Attributes {
@@ -105,7 +106,7 @@ extension Sketch: Attributes {
         settings.rectMode = mode
     }
     
-    public func imageMode(_ mode: ShapeMode) {
+    public func imageMode(_ mode: ImageMode) {
         settings.imageMode = mode
     }
 }

--- a/Sources/SwiftProcessing/Core/SketchEnums.swift
+++ b/Sources/SwiftProcessing/Core/SketchEnums.swift
@@ -37,6 +37,17 @@ extension Sketch {
         case center
     }
     
+    /// The `ImageMode` enum modifies the location from which images are drawn by changing the way in which parameters given to `image()` are interpreted.
+    /// The default mode is `.corner`, which interprets the second and third parameters of `image()` as the upper-left corner of the image. If two additional parameters are specified, they are used to set the image's width and height.
+    /// `.corners` interprets the second and third parameters of `image()` as the location of one corner, and the fourth and fifth parameters as the opposite corner.
+    /// `.center` interprets the second and third parameters of `image()` as the image's center point. If two additional parameters are specified, they are used to set the image's width and height.
+    
+    public enum ImageMode {
+        case corner
+        case corners
+        case center
+    }
+    
     /// The `ArcMode` enum determins how arcs are drawn. `.open` will only draw the exterior of the arc and fill whatever shpae remains. The space between the endpoints will not be stroked. `.chord` is the same as `.open` but will stroke the distance between the two endpoints. `.pie` will treat our arc like a pie and stroke the exterior of the arc as well as from each endpoint to the center.
     
     public enum ArcMode {


### PR DESCRIPTION
SwiftProcessing now correctly honors ImageMode. There is a new enum called ImageMode. Before we used a general enum called ShapeMode, but this causes problems with enum suggestions, as there should not be a `.radius` mode for images and Swift switches must be exhaustive.